### PR TITLE
refactor(gallery): clean up platform and emoji selection logic

### DIFF
--- a/src/components/gallery/Generated.tsx
+++ b/src/components/gallery/Generated.tsx
@@ -361,7 +361,7 @@ export default function GeneratedGalleryImage({
                         whileHover={{ scale: 1.1 }}
                         whileTap={{ scale: 1 }}
                         className={`
-                            absolute left-0 top-0 z-10 flex h-8 w-8 cursor-pointer items-center justify-center rounded border-2 
+                            absolute left-0 top-0 z-10 flex h-8 w-8 cursor-pointer items-center justify-center rounded border-2
                             ${theme == "violet" && " border-violet-200 text-violet-200"}
                             ${theme == "orange" && " border-[#C1410B] text-[#C1410B]"}
                             `}
@@ -440,9 +440,6 @@ export default function GeneratedGalleryImage({
                             collectionId == "wizards",
                         })}
                         onClick={() => {
-                          if (platform === "") {
-                            setSelectedEmojis([]);
-                          }
                           setPlatform(
                             platform === EPlatform.TELEGRAM
                               ? EPlatform.NONE
@@ -463,9 +460,6 @@ export default function GeneratedGalleryImage({
                             collectionId == "wizards",
                         })}
                         onClick={() => {
-                          if (platform === "") {
-                            setSelectedEmojis([]);
-                          }
                           setPlatform(
                             platform === EPlatform.DISCORD
                               ? EPlatform.NONE
@@ -485,8 +479,6 @@ export default function GeneratedGalleryImage({
                         })}
                         variant={theme}
                         onClick={() => {
-                          setSelectedEmojis([]);
-                          setSelectedType("");
                           setPlatform(EPlatform.NONE);
                           setIsDownloading(!isDownloading);
                         }}
@@ -551,7 +543,7 @@ export default function GeneratedGalleryImage({
                             selectedType={selectedType}
                             selected={selectedEmojis.includes(i)}
                             onSelect={() => onSelectEmojis(emoji, i)}
-                            selectEnabled={!!platform}
+                            selectEnabled={!!platform || isDownloading}
                           />
                         ))}
                   </div>

--- a/src/components/gallery/moonbirds/generated.tsx
+++ b/src/components/gallery/moonbirds/generated.tsx
@@ -476,8 +476,8 @@ export default function MoonbirdGenerated({
                       <div className="flex flex-row gap-3 sm:mb-2">
                         <Switch
                           checked={hasBg}
-                          onChange={(checked) => {
-                            setHasBg(checked);
+                          onChange={(isChecked) => {
+                            setHasBg(isChecked);
                           }}
                           className="relative inline-flex h-6 w-11 items-center rounded-full border-2 !border-[#BDBCFF] !bg-[#BDBCFF] transition-colors"
                         >
@@ -502,7 +502,7 @@ export default function MoonbirdGenerated({
                         <Switch
                           checked={allEmojisSelected}
                           disabled={platform === ""}
-                          onChange={(checked) => selectAll()}
+                          onChange={() => selectAll()}
                           className="relative inline-flex h-6 w-11 items-center rounded-full border-2 !border-[#BDBCFF]  !bg-[#BDBCFF] transition-colors"
                         >
                           <span
@@ -560,8 +560,8 @@ export default function MoonbirdGenerated({
                   <div className="mb-2 flex flex-row gap-3">
                     <Switch
                       checked={hasBg}
-                      onChange={(checked) => {
-                        setHasBg(checked);
+                      onChange={(isChecked) => {
+                        setHasBg(isChecked);
                       }}
                       className="relative inline-flex h-6 w-11 items-center rounded-full border-2 !border-[#BDBCFF] !bg-[#BDBCFF] transition-colors"
                     >
@@ -587,7 +587,7 @@ export default function MoonbirdGenerated({
                     <Switch
                       checked={allEmojisSelected}
                       disabled={platform === ""}
-                      onChange={(checked) => selectAll()}
+                      onChange={() => selectAll()}
                       className="relative inline-flex h-6 w-11 items-center rounded-full border-2 !border-[#BDBCFF]  !bg-[#BDBCFF] transition-colors"
                     >
                       <span
@@ -621,7 +621,7 @@ export default function MoonbirdGenerated({
                           platform={platform}
                           selected={selectedEmojis.includes(i)}
                           onSelect={() => onSelectEmojis(i)}
-                          selectEnabled={platform ? true : false}
+                          selectEnabled
                         />
                       ))
                     : generatedEmojisTransparent.map((emoji, i) => (
@@ -632,7 +632,7 @@ export default function MoonbirdGenerated({
                           selectedType="png"
                           selected={selectedEmojis.includes(i)}
                           onSelect={() => onSelectEmojis(i)}
-                          selectEnabled={platform ? true : false}
+                          selectEnabled
                         />
                       ))}
                 </div>


### PR DESCRIPTION
- Remove redundant emoji clearing when changing platforms
- Simplify switch onChange handlers
- Make emoji selection always enabled when downloading